### PR TITLE
Add Tekton CD pipeline

### DIFF
--- a/tekton/pipeline-run.yaml
+++ b/tekton/pipeline-run.yaml
@@ -1,0 +1,22 @@
+apiVersion: tekton.dev/v1
+kind: PipelineRun
+metadata:
+  name: cd-pipeline-run
+spec:
+  pipelineRef:
+    name: cd-pipeline
+
+  workspaces:
+    - name: pipeline-workspace
+      persistentVolumeClaim:
+        claimName: pipelinerun-pvc
+
+  params:
+    - name: repo-url
+      value: https://github.com/ifareseg/devops-capstone-project.git
+    - name: branch
+      value: main
+    - name: image-reference
+      value: image-registry.openshift-image-registry.svc:5000/sn-labs-eslamalfi2/accounts:latest
+    - name: manifest-dir
+      value: k8s

--- a/tekton/pipeline.yaml
+++ b/tekton/pipeline.yaml
@@ -1,38 +1,104 @@
-#
-# This pipeline needs the following tasks from Tekton Catalog
-#   - git-clone
-#   - flake8
-#
----
-apiVersion: tekton.dev/v1beta1
+apiVersion: tekton.dev/v1
 kind: Pipeline
-metadata:  
+metadata:
   name: cd-pipeline
 spec:
   workspaces:
     - name: pipeline-workspace
+
   params:
     - name: repo-url
+      type: string
     - name: branch
+      type: string
       default: main
+    - name: image-reference
+      type: string
+    - name: manifest-dir
+      type: string
+      default: k8s
+
   tasks:
     - name: init
-      workspaces:
-        - name: source
-          workspace: pipeline-workspace          
       taskRef:
         name: cleanup
+      workspaces:
+        - name: source
+          workspace: pipeline-workspace
 
     - name: clone
-      workspaces:
-        - name: output
-          workspace: pipeline-workspace          
       taskRef:
         name: git-clone
-      params:
-      - name: url
-        value: $(params.repo-url)
-      - name: revision
-        value: $(params.branch)
+        kind: ClusterTask
       runAfter:
         - init
+      params:
+        - name: url
+          value: $(params.repo-url)
+        - name: revision
+          value: $(params.branch)
+        - name: deleteExisting
+          value: "true"
+      workspaces:
+        - name: output
+          workspace: pipeline-workspace
+
+    - name: lint
+      taskRef:
+        name: flake8
+      runAfter:
+        - clone
+      params:
+        - name: package
+          value: service
+        - name: args
+          value:
+            - --count
+            - --max-complexity=10
+            - --max-line-length=127
+            - --statistics
+      workspaces:
+        - name: source
+          workspace: pipeline-workspace
+
+    - name: test
+      taskRef:
+        name: nose-tests
+      runAfter:
+        - lint
+      workspaces:
+        - name: source
+          workspace: pipeline-workspace
+
+    - name: build-image
+      taskRef:
+        name: buildah
+        kind: ClusterTask
+      runAfter:
+        - test
+      params:
+        - name: IMAGE
+          value: $(params.image-reference)
+        - name: DOCKERFILE
+          value: ./Dockerfile
+        - name: CONTEXT
+          value: .
+        - name: TLSVERIFY
+          value: "false"
+      workspaces:
+        - name: source
+          workspace: pipeline-workspace
+
+    - name: deploy
+      taskRef:
+        name: kubernetes-deploy
+      runAfter:
+        - build-image
+      params:
+        - name: manifest-dir
+          value: $(params.manifest-dir)
+        - name: image-reference
+          value: $(params.image-reference)
+      workspaces:
+        - name: source
+          workspace: pipeline-workspace

--- a/tekton/pvc.yaml
+++ b/tekton/pvc.yaml
@@ -4,9 +4,9 @@ metadata:
   name: pipelinerun-pvc
 spec:
   storageClassName: skills-network-learner
-  resources:
-    requests:
-      storage:  1Gi
-  volumeMode: Filesystem
   accessModes:
     - ReadWriteMany
+  volumeMode: Filesystem
+  resources:
+    requests:
+      storage: 1Gi

--- a/tekton/tasks.yaml
+++ b/tekton/tasks.yaml
@@ -1,52 +1,57 @@
 ---
-apiVersion: tekton.dev/v1beta1
+apiVersion: tekton.dev/v1
 kind: Task
 metadata:
-  name: echo
+  name: git-clone
 spec:
-  description: This task will echo the message.
+  description: Clone a git repository into the workspace
   params:
-    - name: message
-      description: The message to echo
+    - name: url
       type: string
+    - name: revision
+      type: string
+      default: main
+    - name: deleteExisting
+      type: string
+      default: "true"
+  workspaces:
+    - name: output
   steps:
-    - name: echo-message
-      image: alpine:3
-      command: [/bin/echo]
-      args: ["$(params.message)"]
+    - name: clone
+      image: alpine/git:latest
+      workingDir: $(workspaces.output.path)
+      script: |
+        #!/bin/sh
+        set -eu
+        if [ "$(params.deleteExisting)" = "true" ]; then
+          rm -rf ./* ./.git || true
+        fi
+        git clone $(params.url) .
+        git checkout $(params.revision)
+
 ---
-apiVersion: tekton.dev/v1beta1
+apiVersion: tekton.dev/v1
 kind: Task
 metadata:
-  name: cleanup
+  name: flake8
 spec:
-  description: This task will clean up a workspace by deleting all of the files.
+  description: Run flake8 lint checks
+  params:
+    - name: package
+      type: string
+      default: service
+    - name: args
+      type: array
+      default: []
   workspaces:
     - name: source
   steps:
-    - name: remove
-      image: alpine:3
-      env:
-        - name: WORKSPACE_SOURCE_PATH
-          value: $(workspaces.source.path)
+    - name: lint
+      image: python:3.9-slim
       workingDir: $(workspaces.source.path)
-      securityContext:
-        runAsNonRoot: false
-        runAsUser: 0
       script: |
-        #!/usr/bin/env sh
+        #!/bin/sh
         set -eu
-        echo "Removing all files from ${WORKSPACE_SOURCE_PATH} ..."
-        # Delete any existing contents of the directory if it exists.
-        #
-        # We don't just "rm -rf ${WORKSPACE_SOURCE_PATH}" because ${WORKSPACE_SOURCE_PATH} might be "/"
-        # or the root of a mounted volume.
-        if [ -d "${WORKSPACE_SOURCE_PATH}" ] ; then
-          # Delete non-hidden files and directories
-          rm -rf "${WORKSPACE_SOURCE_PATH:?}"/*
-          # Delete files and directories starting with . but excluding ..
-          rm -rf "${WORKSPACE_SOURCE_PATH}"/.[!.]*
-          # Delete files and directories starting with .. plus any other character
-          rm -rf "${WORKSPACE_SOURCE_PATH}"/..?*
-        fi
-
+        pip install --upgrade pip wheel
+        pip install -r requirements.txt
+        flake8 $(params.package) --count --max-complexity=10 --max-line-length=127 --statistics

--- a/tekton/tasks.yaml
+++ b/tekton/tasks.yaml
@@ -2,6 +2,99 @@
 apiVersion: tekton.dev/v1
 kind: Task
 metadata:
+  name: echo
+spec:
+  description: This task will echo the message.
+  params:
+    - name: message
+      description: The message to echo
+      type: string
+  steps:
+    - name: echo-message
+      image: alpine:3
+      command: ["/bin/echo"]
+      args: ["$(params.message)"]
+
+---
+apiVersion: tekton.dev/v1
+kind: Task
+metadata:
+  name: cleanup
+spec:
+  description: This task will clean up a workspace by deleting all of the files.
+  workspaces:
+    - name: source
+  steps:
+    - name: remove
+      image: alpine:3
+      env:
+        - name: WORKSPACE_SOURCE_PATH
+          value: $(workspaces.source.path)
+      workingDir: $(workspaces.source.path)
+      securityContext:
+        runAsNonRoot: false
+        runAsUser: 0
+      script: |
+        #!/usr/bin/env sh
+        set -eu
+        echo "Removing all files from ${WORKSPACE_SOURCE_PATH} ..."
+        if [ -d "${WORKSPACE_SOURCE_PATH}" ] ; then
+          rm -rf "${WORKSPACE_SOURCE_PATH:?}"/*
+          rm -rf "${WORKSPACE_SOURCE_PATH}"/.[!.]*
+          rm -rf "${WORKSPACE_SOURCE_PATH}"/..?*
+        fi
+
+---
+apiVersion: tekton.dev/v1
+kind: Task
+metadata:
+  name: nose-tests
+spec:
+  description: Run unit tests with nosetests
+  workspaces:
+    - name: source
+  steps:
+    - name: run-tests
+      image: python:3.9-slim
+      workingDir: $(workspaces.source.path)
+      script: |
+        #!/bin/sh
+        set -eu
+        pip install --upgrade pip wheel
+        pip install -r requirements.txt
+        nosetests
+
+---
+apiVersion: tekton.dev/v1
+kind: Task
+metadata:
+  name: flake8
+spec:
+  description: Run flake8 lint checks
+  params:
+    - name: package
+      type: string
+      default: service
+    - name: args
+      type: array
+      default: []
+  workspaces:
+    - name: source
+  steps:
+    - name: lint
+      image: python:3.9-slim
+      workingDir: $(workspaces.source.path)
+      script: |
+        #!/bin/sh
+        set -eu
+        pip install --upgrade pip wheel
+        pip install -r requirements.txt
+        flake8 $(params.package) --count --max-complexity=10 --max-line-length=127 --statistics
+
+---
+apiVersion: tekton.dev/v1
+kind: Task
+metadata:
   name: git-clone
 spec:
   description: Clone a git repository into the workspace
@@ -33,25 +126,34 @@ spec:
 apiVersion: tekton.dev/v1
 kind: Task
 metadata:
-  name: flake8
+  name: kubernetes-deploy
 spec:
-  description: Run flake8 lint checks
+  description: Deploy manifests to Kubernetes/OpenShift
   params:
-    - name: package
+    - name: manifest-dir
       type: string
-      default: service
-    - name: args
-      type: array
-      default: []
+      default: k8s
+    - name: image-reference
+      type: string
   workspaces:
     - name: source
   steps:
-    - name: lint
-      image: python:3.9-slim
+    - name: apply-manifests
+      image: bitnami/kubectl:latest
       workingDir: $(workspaces.source.path)
       script: |
         #!/bin/sh
         set -eu
-        pip install --upgrade pip wheel
-        pip install -r requirements.txt
-        flake8 $(params.package) --count --max-complexity=10 --max-line-length=127 --statistics
+
+        echo "Updating deployment image to $(params.image-reference)"
+        sed -i "s|image: .*|image: $(params.image-reference)|" $(params.manifest-dir)/deployment.yaml
+
+        echo "Applying Kubernetes manifests"
+        kubectl apply -f $(params.manifest-dir)/postgres.yaml
+        kubectl apply -f $(params.manifest-dir)/postgres-service.yaml
+        kubectl apply -f $(params.manifest-dir)/deployment.yaml
+        kubectl apply -f $(params.manifest-dir)/service.yaml
+
+        if [ -f "$(params.manifest-dir)/route.yaml" ]; then
+          kubectl apply -f $(params.manifest-dir)/route.yaml || true
+        fi

--- a/tekton/tasks.yaml
+++ b/tekton/tasks.yaml
@@ -1,4 +1,3 @@
----
 apiVersion: tekton.dev/v1
 kind: Task
 metadata:
@@ -12,8 +11,10 @@ spec:
   steps:
     - name: echo-message
       image: alpine:3
-      command: ["/bin/echo"]
-      args: ["$(params.message)"]
+      command:
+        - /bin/echo
+      args:
+        - $(params.message)
 
 ---
 apiVersion: tekton.dev/v1
@@ -57,6 +58,9 @@ spec:
     - name: run-tests
       image: python:3.9-slim
       workingDir: $(workspaces.source.path)
+      env:
+        - name: DATABASE_URI
+          value: sqlite:///test.db
       script: |
         #!/bin/sh
         set -eu
@@ -75,9 +79,6 @@ spec:
     - name: package
       type: string
       default: service
-    - name: args
-      type: array
-      default: []
   workspaces:
     - name: source
   steps:
@@ -139,21 +140,26 @@ spec:
     - name: source
   steps:
     - name: apply-manifests
-      image: bitnami/kubectl:latest
+      image: image-registry.openshift-image-registry.svc:5000/openshift/cli:latest
       workingDir: $(workspaces.source.path)
       script: |
         #!/bin/sh
         set -eu
 
         echo "Updating deployment image to $(params.image-reference)"
-        sed -i "s|image: .*|image: $(params.image-reference)|" $(params.manifest-dir)/deployment.yaml
+
+        rm -rf /tmp/manifests
+        mkdir -p /tmp/manifests
+        cp -R $(params.manifest-dir)/* /tmp/manifests/
+
+        sed -i "s|image: .*|image: $(params.image-reference)|" /tmp/manifests/deployment.yaml
 
         echo "Applying Kubernetes manifests"
-        kubectl apply -f $(params.manifest-dir)/postgres.yaml
-        kubectl apply -f $(params.manifest-dir)/postgres-service.yaml
-        kubectl apply -f $(params.manifest-dir)/deployment.yaml
-        kubectl apply -f $(params.manifest-dir)/service.yaml
+        kubectl apply -f /tmp/manifests/postgres.yaml
+        kubectl apply -f /tmp/manifests/postgres-service.yaml
+        kubectl apply -f /tmp/manifests/deployment.yaml
+        kubectl apply -f /tmp/manifests/service.yaml
 
-        if [ -f "$(params.manifest-dir)/route.yaml" ]; then
-          kubectl apply -f $(params.manifest-dir)/route.yaml || true
+        if [ -f /tmp/manifests/route.yaml ]; then
+          kubectl apply -f /tmp/manifests/route.yaml || true
         fi


### PR DESCRIPTION
## Summary

This PR adds a complete Continuous Delivery (CD) pipeline using Tekton.

## Changes

- Added Tekton tasks:
  - git-clone
  - flake8 (lint)
  - nose-tests (unit tests)
  - buildah (build and push image)
  - kubernetes-deploy

- Created pipeline to:
  - Clone source code
  - Run lint checks
  - Run unit tests
  - Build container image
  - Deploy application to OpenShift

- Fixed deployment issue by:
  - Copying manifests to /tmp before applying changes
  - Avoiding permission errors with sed

## Result

- Pipeline runs successfully
- Image is built and pushed to OpenShift registry
- Application is deployed successfully
- Route is created and accessible

## Notes

- Unit tests configured to use SQLite instead of PostgreSQL
- Deployment uses dynamic image reference